### PR TITLE
Fix CPU training and backprop

### DIFF
--- a/semisupervised/codes/gnn.py
+++ b/semisupervised/codes/gnn.py
@@ -29,8 +29,10 @@ def mixup_gnn_hidden(x, target, train_idx, alpha):
     else:
         lam = 1.
     permuted_train_idx = train_idx[torch.randperm(train_idx.shape[0])]
-    x[train_idx] = lam*x[train_idx]+ (1-lam)*x[permuted_train_idx]
-    return x, target[train_idx], target[permuted_train_idx],lam
+    # autograd doesnt work if tensors are modified in-place, make a copy instead
+    x_new = x.clone()
+    x_new[train_idx] = lam*x[train_idx]+ (1-lam)*x[permuted_train_idx]
+    return x_new, target[train_idx], target[permuted_train_idx],lam
 
 
 

--- a/semisupervised/codes/train.py
+++ b/semisupervised/codes/train.py
@@ -186,7 +186,10 @@ def train(epoches):
             trainer.optimizer.zero_grad()
             k = 10
             temp  = torch.zeros([k, target_q.shape[0], target_q.shape[1]], dtype=target_q.dtype)
-            temp = temp.cuda()
+            # move tensors to GPU only if its available
+            # TODO: use .to(device)
+            if opt['cuda']:
+                temp = temp.cuda()
             for i in range(k):
                 temp[i,:,:] = trainer.predict_noisy(inputs_q)
             target_predict = temp.mean(dim = 0)


### PR DESCRIPTION
- Move the `temp` tensor to GPU only if CUDA is enabled by using `opt['cuda']`
- Replace in-place modification of a tensor with a clone operation

Tested on PyTorch 1.2.0, Ubuntu 16.04